### PR TITLE
Do not freeze string literals

### DIFF
--- a/Formula/fnm.rb
+++ b/Formula/fnm.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # Fnm formula :D
 class Fnm < Formula
   attr_accessor :shell_configuration_failure


### PR DESCRIPTION
`frozen_string_literal` pragma breaks [`homebrew-livecheck`](https://github.com/Homebrew/homebrew-livecheck) 🤷‍♂ 