### PR TITLE
Format `fnm` formula using `brew audit --fix`

### DIFF
--- a/Formula/fnm.rb
+++ b/Formula/fnm.rb
@@ -1,28 +1,20 @@
-# frozen_string_literal: true
-
-# Fnm formula :D
 class Fnm < Formula
   attr_accessor :shell_configuration_failure
 
-  VERSION = '1.20.0'
-  desc 'Fast and simple Node.js version manager'
-  homepage 'https://github.com/Schniz/fnm'
+  VERSION = "1.20.0".freeze
+  desc "Fast and simple Node.js version manager"
+  homepage "https://github.com/Schniz/fnm"
   url "https://github.com/Schniz/fnm/releases/download/v#{VERSION}/fnm-macos.zip"
-  version VERSION
-  sha256 '3574a2df4fd5a484c6c4f848cf86a08c6393be252b0bf0984debb863f52638a4'
+  sha256 "3574a2df4fd5a484c6c4f848cf86a08c6393be252b0bf0984debb863f52638a4"
 
   bottle :unneeded
 
-  test do
-    system "#{bin}/fnm", '--version'
-  end
-
   def install
-    bin.install 'fnm'
+    bin.install "fnm"
   end
 
   def caveats
-    <<~CAVEATS
+    <<~EOS
       Thanks for installing fnm!
       The last step for making fnm work is to run it on the shell startup, using the `fnm env` command.
 
@@ -36,14 +28,18 @@ class Fnm < Formula
 
       > btw, if you know how to make this process automated, help us out with a PR!
       > the code is here: https://github.com/Schniz/homebrew-tap/blob/master/Formula/fnm.rb
-    CAVEATS
+    EOS
+  end
+
+  test do
+    system "#{bin}/fnm", "--version"
   end
 
   def source_for_shell
-    if preferred == 'fish'
-      'fnm env --multi | source'
+    if preferred == "fish"
+      "fnm env --multi | source"
     else
-      %{eval "$(fnm env --multi)"}
+      'eval "$(fnm env --multi)"'
     end
   end
 end

--- a/Formula/fnm.rb
+++ b/Formula/fnm.rb
@@ -11,6 +11,21 @@ class Fnm < Formula
 
   def install
     bin.install "fnm"
+    chmod "+x", bin/"fnm"
+    %w[
+      alias
+      default
+      env
+      exec
+      install
+      ls
+      ls-remote
+      uninstall
+      use
+    ].each do |cmd|
+      (man1/"fnm-#{cmd}.1").write `#{bin}/fnm #{cmd} --help=groff`
+    end
+    (man1/"fnm.1").write `#{bin}/fnm --help=groff`
   end
 
   def caveats


### PR DESCRIPTION
- using explicit `.freeze` instead of pragma due to `brew livecheck` issue #7 
- removing unnecessary version descriptor, version is inferred from the download URL