### PR TITLE
Show the correct post-install instructions for fish

### DIFF
--- a/Formula/fnm.rb
+++ b/Formula/fnm.rb
@@ -40,7 +40,7 @@ class Fnm < Formula
   end
 
   def source_for_shell
-    if preferred == 'fish'
+    if preferred == :fish
       'fnm env --multi | source'
     else
       %{eval "$(fnm env --multi)"}


### PR DESCRIPTION
The `preferred` method from homebrew returns a [symbol](https://github.com/Homebrew/brew/blob/b2ccf3ba789cda29028b94a048385b8f2dafd8c6/Library/Homebrew/utils/shell.rb#L14), not a string, so the current instructions for fish are incorrect.
I also had this issue https://github.com/Schniz/fnm/issues/213 and adding the correct command to my fish config fixed the issue for me.